### PR TITLE
If it's not an anchor link include the role:'link' prop.

### DIFF
--- a/packages/svelte/src/Link.svelte
+++ b/packages/svelte/src/Link.svelte
@@ -35,7 +35,7 @@
     headers,
     queryStringArrayFormat,
   }}
-  {...as === 'a' ? { href } : {}}
+  {...as !== 'a' ? { href } : {role:'link'}}
   {...$$restProps}
   on:focus
   on:blur


### PR DESCRIPTION
Small QOL / accessibility improvement off the back of a discussion in Discord.

https://media.discordapp.net/attachments/915652221474046002/1188918416887795843/CleanShot_2023-12-25_at_19.52.552x.png?ex=65a5800f&is=65930b0f&hm=71f359bd0794339451bcf74fb6f242ee60d389cef2a48479cdbd039aec5d9603&=&format=webp&quality=lossless&width=3840&height=1172